### PR TITLE
Fixes Error when using "_pagination" => "code" in PHP Client

### DIFF
--- a/lib/Core.php
+++ b/lib/Core.php
@@ -300,7 +300,12 @@ class SparkAPI_Core {
 
 			if ($json['D']['Success'] == true) {
 				$return['success'] = true;
-				$return['results'] = $json['D']['Results'];
+        if (array_key_exists('Results', $json['D'])) {
+          $return['results'] = $json['D']['Results'];
+        }
+        else {
+          $return['results'] = array();
+        }
 			}
 			else {
 				$return['success'] = false;


### PR DESCRIPTION
$return['results'] is set to an empty array if the 'Results' attributes is missing.
