### PR TITLE
Closes Issue #4

### DIFF
--- a/lib/Core.php
+++ b/lib/Core.php
@@ -252,7 +252,7 @@ class SparkAPI_Core {
 
 		if ($this->cache and $method == "GET" and $a_retry != true and $seconds_to_cache > 0) {
 			$response = $this->cache->get($this->make_cache_key($request));
-			if ($response) {
+			if ($response !== null) {
 				$served_from_cache = true;
 			}
 		}

--- a/lib/MySQLiCache.php
+++ b/lib/MySQLiCache.php
@@ -45,10 +45,15 @@ class SparkAPI_MySQLiCache implements SparkAPI_CacheInterface {
 		if ($result = $this->conn->query($sql)) {
 			$row = $result->fetch_assoc();
 			if ($row !== null) {
-				return unserialize($row['cache_value']);
+				if(!$return = unserialize($row['cache_value'])){
+					return null;
+				} else {
+					return $return;
+				}
 			}
 		}
-		return false;
+
+		return null;
 	}
 
 	function set($key, $value, $expire) {


### PR DESCRIPTION
This just checks for a result from the unserialize in the mysqli cache-- if no result, returns null rather than false, so that the check for "served_from_cache" will function properly.

Also changed default mysql cache table definition in examples.php to use LONGBLOB, though BLOB may be adequate.
