### PR TITLE
Added support for Composer installs/updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "sparkapi/sparkapi",
+    "type": "library",
+    "description": "PHP wrapper for the Spark REST API",
+    "keywords": ["spark", "sparkapi"],
+    "homepage": "http://github.com/sparkapi/sparkapi4p2",
+    "license": "GPL-3.0",
+    "require": {
+        "php": ">=5.2.0"
+    },
+    "autoload": {
+        "classmap": ["lib/"]
+    }
+}


### PR DESCRIPTION
Added the configuration file needed for Composer (dependency manager for PHP) so that the PHP API client could be included in other projects using Composer.

By adding:

``` json
{
  "require": {
    "sparkapi/sparkapi": "dev-master"
  }
}
```

to a project's `composer.json` file and running `php composer.phar update` (or `composer update` if Composer is installed globally), the API client will be downloaded/updated and automatically included within the project with the latest code from the `master` branch.
