### PR TITLE
URL Encode to handle escapes in URL

### DIFF
--- a/lib/Core.php
+++ b/lib/Core.php
@@ -821,7 +821,7 @@ class SparkAPI_Core {
 		if ($post_data) {
 			$post_data = $this->make_sendable_body($post_data);
 		}
-		$service = urlencode($service);
+		$service = rawurlencode($service);
 		$service = trim($service, "/ ");
 
 		return $this->MakeAPICall($method, $service, $cache_time, $params, $post_data, $a_retry);


### PR DESCRIPTION
Adding urlencode to $services to handle calls such as /contacts/tags/<Tag>.
