### PR TITLE
Change wrapped_api_call method to only escape /v1/contacts/tags/<tag>

### DIFF
--- a/lib/Core.php
+++ b/lib/Core.php
@@ -833,9 +833,11 @@ class SparkAPI_Core {
 
 		$tagstest = explode("/", $service);
 
-		if ($tagstest[1] == "tags" and count($tagstest) == 3) {
-			$tagstest[2] = rawurlencode($tagstest[2]);
-			$service = implode("/", $tagstest);
+		if (count($tagstest) >= 3) {
+			if ($tagstest[1] == "tags") {
+				echo $tagstest[2] = rawurlencode($tagstest[2]);
+				echo $service = implode("/", $tagstest);
+			}
 		}
 
 		$service = trim($service, "/ ");


### PR DESCRIPTION
Ok, the whole url was being escaped when it shouldn't have.

But we still needed it to escape whenever calling /v1/contacts/tags/<tag>.

So, the new code checks for this.  Couldn't think of any other service
that would need to be escaped before hand so just leaving it simple.
