### PR TITLE
Compliance with TLS 1.2

### DIFF
--- a/lib/CurlTransport.php
+++ b/lib/CurlTransport.php
@@ -12,6 +12,7 @@ class SparkAPI_CurlTransport extends SparkAPI_CoreTransport implements SparkAPI_
 		curl_setopt($this->ch, CURLOPT_SSL_VERIFYHOST, false);
 		curl_setopt($this->ch, CURLOPT_SSL_VERIFYPEER, false);
 		curl_setopt($this->ch, CURLOPT_ENCODING, "gzip");
+		curl_setopt($this->ch, CURLOPT_SSLVERSION, 6);
 	}
 	
 	function __destruct() {


### PR DESCRIPTION
Hello, with the new standards it is required that at least TLS 1.2 is used, under previous version than PHP 7, it is not "assumed" as TLS 1.2, this change will ensure 1.2 is used.