### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/lib/Core.php
+++ b/lib/Core.php
@@ -834,7 +834,7 @@ class SparkAPI_Core {
 
 		$token = null;
 		if (array_key_exists('success', $json)) {
-			if ($json['success'] == True) {
+			if ($json['success'] == true) {
 				$token = $json["token"];
 			}
 			else {


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!